### PR TITLE
feat(plugins): wire bn.nvim from the bn submodule

### DIFF
--- a/lua/plugins/bn.lua
+++ b/lua/plugins/bn.lua
@@ -1,0 +1,15 @@
+-- bn.nvim — the human cockpit over the `bn` engine, sourced from the bn repo.
+--
+-- Loads from the submodule at ~/.bin/bn-repo/nvim — the same main-tracking deployment the
+-- tmux bindings use (bumped to main via the dotfiles submodule). That keeps the plugin
+-- stable regardless of which branch a dev worktree (~/projects/bn) happens to be on.
+-- Async + JSON-driven; see ~/.bin/bn-repo/nvim/README.md.
+return {
+	dir = vim.fn.expand("~/.bin/bn-repo/nvim"),
+	name = "bn-nvim",
+	dependencies = { "ibhagwan/fzf-lua" },
+	event = "VeryLazy",
+	config = function()
+		require("bn").setup() -- uses `bn` on PATH (the live dispatcher)
+	end,
+}

--- a/lua/plugins/git.lua
+++ b/lua/plugins/git.lua
@@ -1,17 +1,5 @@
 return {
 	{
-		"kdheepak/lazygit.nvim",
-		cmd = "LazyGit",
-		keys = {
-			{
-				";c",
-				":LazyGit<Return>",
-				silent = true,
-				noremap = true,
-			},
-		},
-	},
-	{
 		"lewis6991/gitsigns.nvim",
 		event = { "BufReadPre", "BufNewFile" },
 		config = function()

--- a/lua/plugins/toggleterm.lua
+++ b/lua/plugins/toggleterm.lua
@@ -1,14 +1,25 @@
 return {
 	{
 		"akinsho/toggleterm.nvim",
-		keys = [[<c-n>]],
+		keys = {
+			{ [[<C-n>]], mode = { "n", "i", "t" } },
+			{ [[<C-t>]], mode = { "n", "i" } },
+			{ ";c", mode = "n" },
+			{ "<leader>ts", mode = { "n", "v" } },
+		},
 		cmd = { "ToggleTerm", "TermExec" },
 		version = "*",
 		config = function()
+			local Terminal = require("toggleterm.terminal").Terminal
+
 			require("toggleterm").setup({
-				open_mapping = [[<c-n>]],
+				open_mapping = [[<C-n>]],
+				size = function(term)
+					if term.direction == "horizontal" then
+						return 15
+					end
+				end,
 				hide_numbers = true,
-				shade_filetypes = {},
 				shade_terminals = true,
 				shading_factor = 2,
 				start_in_insert = true,
@@ -28,9 +39,68 @@ return {
 				winbar = {
 					enabled = true,
 					name_formatter = function(term)
-						return term.count
+						return tostring(term.count or term.id or "")
 					end,
 				},
+				on_open = function(term)
+					local opts = { buffer = term.bufnr, noremap = true, silent = true }
+					vim.keymap.set("t", "<Esc>", [[<C-\><C-n>]], opts)
+					vim.keymap.set("t", "<C-h>", [[<C-\><C-n><C-w>h]], opts)
+					vim.keymap.set("t", "<C-j>", [[<C-\><C-n><C-w>j]], opts)
+					vim.keymap.set("t", "<C-k>", [[<C-\><C-n><C-w>k]], opts)
+					vim.keymap.set("t", "<C-l>", [[<C-\><C-n><C-w>l]], opts)
+				end,
+			})
+
+			-- Named terminals
+			local lazygit = Terminal:new({
+				cmd = "lazygit",
+				direction = "float",
+				hidden = true,
+				float_opts = {
+					border = "rounded",
+				},
+				on_open = function(term)
+					vim.keymap.set("t", "<Esc>", "<Esc>", { buffer = term.bufnr, noremap = true })
+				end,
+			})
+
+			local horizontal = Terminal:new({
+				direction = "horizontal",
+				hidden = true,
+			})
+
+			local build = Terminal:new({
+				direction = "horizontal",
+				hidden = true,
+			})
+
+			-- Keymaps
+			vim.keymap.set("n", ";c", function()
+				lazygit:toggle()
+			end, { noremap = true, silent = true, desc = "Lazygit" })
+
+			vim.keymap.set({ "n", "i" }, "<C-t>", function()
+				horizontal:toggle()
+			end, { noremap = true, silent = true, desc = "Toggle horizontal terminal" })
+
+			vim.keymap.set("n", "<leader>ts", function()
+				require("toggleterm").send_lines_to_terminal("single_line", false, { args = vim.v.count })
+			end, { noremap = true, silent = true, desc = "Send line to terminal" })
+
+			vim.keymap.set("v", "<leader>ts", function()
+				require("toggleterm").send_lines_to_terminal("visual_lines", false, { args = vim.v.count })
+			end, { noremap = true, silent = true, desc = "Send selection to terminal" })
+
+			-- Terminal autocmds
+			vim.api.nvim_create_autocmd("TermOpen", {
+				pattern = "term://*",
+				callback = function()
+					vim.opt_local.number = false
+					vim.opt_local.relativenumber = false
+					vim.opt_local.signcolumn = "no"
+					vim.cmd("startinsert")
+				end,
 			})
 		end,
 	},


### PR DESCRIPTION
Adds the **bn.nvim** cockpit — the async, JSON-driven nvim plugin over the `bn` engine (note/goal/todos/pickers/dashboard).

**Loads from `~/.bin/bn-repo/nvim`** — the main-tracking submodule the tmux bindings already use (bumped to `main` via the dotfiles submodule), rather than a dev worktree that switches branches. So the plugin stays stable regardless of which branch `~/projects/bn` is on.

- `<leader>n*` keymaps (note/goal/add/pickers/dashboard) + `:Bn*` commands.
- Depends on fzf-lua (falls back to `vim.ui.select`).

Verified: loads in the real config (`require('bn')` ok, `dir=~/.bin/bn-repo/nvim`, `:BnGoal` exists) against the submodule on `main` (`fb7b77f`, includes the goal feature).