### PR TITLE
feat(plugins): wire bn.nvim from the bn submodule

### DIFF
--- a/lua/plugins/bn.lua
+++ b/lua/plugins/bn.lua
@@ -1,0 +1,15 @@
+-- bn.nvim — the human cockpit over the `bn` engine, sourced from the bn repo.
+--
+-- Loads from the submodule at ~/.bin/bn-repo/nvim — the same main-tracking deployment the
+-- tmux bindings use (bumped to main via the dotfiles submodule). That keeps the plugin
+-- stable regardless of which branch a dev worktree (~/projects/bn) happens to be on.
+-- Async + JSON-driven; see ~/.bin/bn-repo/nvim/README.md.
+return {
+	dir = vim.fn.expand("~/.bin/bn-repo/nvim"),
+	name = "bn-nvim",
+	dependencies = { "ibhagwan/fzf-lua" },
+	event = "VeryLazy",
+	config = function()
+		require("bn").setup() -- uses `bn` on PATH (the live dispatcher)
+	end,
+}


### PR DESCRIPTION
Adds the **bn.nvim** cockpit — async, JSON-driven nvim plugin over the `bn` engine (note/goal/todos/pickers/dashboard).

Loads from `~/.bin/bn-repo/nvim` — the main-tracking submodule the tmux bindings already use — so it stays stable regardless of which branch a dev worktree is on. `<leader>n*` keymaps + `:Bn*` commands; depends on fzf-lua (falls back to vim.ui.select).

Based on current `main` (139695f). Verified: loads in the real config, `require('bn')` ok, `:BnGoal` exists, against the bn submodule on main (fb7b77f, includes goal feature).